### PR TITLE
Add test fixes

### DIFF
--- a/corr/tests/build_arm64.sh
+++ b/corr/tests/build_arm64.sh
@@ -8,12 +8,12 @@ TESTDIR=$PWD
 ODIR=$TESTDIR/`basename $0`.out
 
 mkdir -p bin
-PATH=$TESTDIR/bin/:$PATH
+PATH=$TESTDIR/bin/lkp-tests/kbuild/:$PATH
 
-if [ ! -x ./bin/make.cross ]
+if [ ! -x ./bin/lkp-tests/kbuild/make.cross ]
 then
-	wget https://raw.githubusercontent.com/intel/lkp-tests/master/sbin/make.cross -O ./bin/make.cross
-	chmod +x ./bin/make.cross
+	git clone https://github.com/intel/lkp-tests ./bin/lkp-tests
+	chmod +x ./bin/lkp-tests/kbuild/make.cross
 fi
 
 mkdir -p $ODIR
@@ -25,6 +25,7 @@ cat "$TESTDIR/damon_config" >> $ODIR/.config
 export COMPILER_INSTALL_PATH=$HOME/0day
 export COMPILER=gcc-9.3.0
 export ARCH=arm64
+export URL=https://cdn.kernel.org/pub/tools/crosstool/files/bin/x86_64/9.3.0
 
 make.cross O=$ODIR olddefconfig
 make.cross O=$ODIR -j$(nproc)

--- a/corr/tests/build_m68k.sh
+++ b/corr/tests/build_m68k.sh
@@ -12,10 +12,12 @@ ODIR=$TESTDIR/`basename $0`.out
 mkdir -p bin
 PATH=$TESTDIR/bin/:$PATH
 
-if [ ! -x ./bin/make.cross ]
+PATH=$TESTDIR/bin/lkp-tests/kbuild/:$PATH
+
+if [ ! -x ./bin/lkp-tests/kbuild/make.cross ]
 then
-	wget https://raw.githubusercontent.com/intel/lkp-tests/master/sbin/make.cross -O ./bin/make.cross
-	chmod +x ./bin/make.cross
+	git clone https://github.com/intel/lkp-tests ./bin/lkp-tests
+	chmod +x ./bin/lkp-tests/kbuild/make.cross
 fi
 
 mkdir -p $ODIR
@@ -26,7 +28,8 @@ echo 'CONFIG_MODULES=y' >> $ODIR/.config
 cat "$TESTDIR/damon_config" >> "$ODIR/.config"
 
 export COMPILER_INSTALL_PATH=$HOME/0day
-export GCC_VERSION=7.5.0
+export COMPILER=gcc-7.5.0
+export URL=https://cdn.kernel.org/pub/tools/crosstool/files/bin/x86_64/7.5.0
 
 make.cross O=$ODIR ARCH=m68k olddefconfig
 make.cross O=$ODIR ARCH=m68k -j`grep -e '^processor' /proc/cpuinfo | wc -l`

--- a/corr/tests/huge_count_read_write.c
+++ b/corr/tests/huge_count_read_write.c
@@ -6,7 +6,7 @@
 void test(char *file)
 {
 	int filedesc = open(file, O_RDWR);
-	char buf[25];
+	char buf[512];
 	int ret;
 
 	printf("test %s\n", file);

--- a/corr/tests/huge_count_read_write.sh
+++ b/corr/tests/huge_count_read_write.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
 
+set -e
+
 dmesg -C
 
 for file in /sys/kernel/debug/damon/*


### PR DESCRIPTION
## Issue with build_m68k.sh and build_arm.sh tests
Old make.cross download link isn't valid and wget was creating empty file that always returned 0 upon execution:
```
ubuntu@ip-172-31-10-42:~/linux/tools/testing/selftests/damon-tests$ ls -al bin/make.cross
-rwxr-xr-x 1 root root 0 Aug  5 03:43 bin/make.cross
~/linux/tools/testing/selftests/damon-tests$ ./bin/make.cross && echo $?
0
```

### Testing
Before applying this fix there were only prep files in $ODIR folder:
```
~/linux/tools/testing/selftests/damon-tests/build_m68k.sh.out$ ls
Makefile  include  scripts  source

~/linux/tools/testing/selftests/damon-tests/build_arm64.sh.out$ ls
Makefile  include  scripts  source
```

After fix there are expected build results:
```
ubuntu@ip-172-31-10-42:~/linux/tools/testing/selftests/damon-tests$ ls build_m68k.sh.out
Makefile        System.map  block       certs   drivers  include  io_uring  kernel  mm               modules.builtin.modinfo  scripts   sound   usr   vmlinux    vmlinux.gz
Module.symvers  arch        built-in.a  crypto  fs       init     ipc       lib     modules.builtin  modules.order            security  source  virt  vmlinux.a  vmlinux.o

ubuntu@ip-172-31-10-42:~/linux/tools/testing/selftests/damon-tests$ ls build_arm64.sh.out
Makefile  System.map  arch  block  built-in.a  certs  crypto  drivers  fs  include  init  io_uring  ipc  kernel  lib  mm  modules.builtin  modules.builtin.modinfo  scripts  security  sound  source  usr  virt  vmlinux  vmlinux.a  vmlinux.o  vmlinux.symvers
```

## issue with huge count test
Due to a small buffer test was failing with stack smash crash unnoticed:
```
ubuntu@ip-172-31-10-42:~/linux/tools/testing/selftests/damon-tests$ sudo ./huge_count_read_write.sh
test /sys/kernel/debug/damon/DEPRECATED
after write: : Invalid argument
after read: : Invalid argument
*** stack smashing detected ***: terminated
./huge_count_read_write.sh: line 6: 243359 Aborted                 (core dumped) ./huge_count_read_write "$file"
```

After applying fix I was able to run full test:
```
~/linux/tools/testing/selftests/damon-tests$ sudo ./huge_count_read_write.sh
test /sys/kernel/debug/damon/DEPRECATED
after write: : Invalid argument
after read: : Invalid argument
test /sys/kernel/debug/damon/attrs
after write: : Cannot allocate memory
after read: : Cannot allocate memory
test /sys/kernel/debug/damon/init_regions
...
after write: : Cannot allocate memory
after read: : Cannot allocate memory
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.