### PR TITLE
corr/tests/{build_arm64|build_m68k}.sh: Do not use restricted build options from make.cross

### DIFF
--- a/corr/tests/build_arm64.sh
+++ b/corr/tests/build_arm64.sh
@@ -13,6 +13,8 @@ PATH=$TESTDIR/bin/lkp-tests/kbuild/:$PATH
 if [ ! -x ./bin/lkp-tests/kbuild/make.cross ]
 then
 	git clone https://github.com/intel/lkp-tests ./bin/lkp-tests
+	# Disable restricted kernel compilation flags
+	echo "" > ./bin/lkp-tests/kbuild/etc/kbuild-kcflags
 	chmod +x ./bin/lkp-tests/kbuild/make.cross
 fi
 

--- a/corr/tests/build_m68k.sh
+++ b/corr/tests/build_m68k.sh
@@ -17,6 +17,8 @@ PATH=$TESTDIR/bin/lkp-tests/kbuild/:$PATH
 if [ ! -x ./bin/lkp-tests/kbuild/make.cross ]
 then
 	git clone https://github.com/intel/lkp-tests ./bin/lkp-tests
+	# Disable restricted kernel compilation flags
+	echo "" > ./bin/lkp-tests/kbuild/etc/kbuild-kcflags
 	chmod +x ./bin/lkp-tests/kbuild/make.cross
 fi
 


### PR DESCRIPTION
kbuild-kcflags file stores gcc flags that make kernel compilation more strict. This helps to find more issues in the kernel but this is not what we want to test in this unit test, so lets disable them and compile kernel as regular user would do.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Testing with empty file OK
```
~/linux/tools/testing/selftests/damon-tests$ ls -al ./bin/lkp-tests/kbuild/etc/kbuild-kcflags
-rw-r--r-- 1 root root 1 Aug  5 22:56 ./bin/lkp-tests/kbuild/etc/kbuild-kcflags

~/linux/tools/testing/selftests/damon-tests$ ls build_m68k.sh.out/
Makefile        System.map  block       certs   drivers  include  io_uring  kernel  mm               modules.builtin.modinfo  scripts   sound   usr   vmlinux    vmlinux.gz
Module.symvers  arch        built-in.a  crypto  fs       init     ipc       lib     modules.builtin  modules.order            security  source  virt  vmlinux.a  vmlinux.o

~/linux/tools/testing/selftests/damon-tests$ ls build_arm64.sh.out/
Makefile  System.map  arch  block  built-in.a  certs  crypto  drivers  fs  include  init  io_uring  ipc  kernel  lib  mm  modules.builtin  modules.builtin.modinfo  scripts  security  sound  source  usr  virt  vmlinux  vmlinux.a  vmlinux.o  vmlinux.symvers
```